### PR TITLE
Add support for photos from a Venue endpoint

### DIFF
--- a/fixture/vcr_cassettes/photo_for_venue.json
+++ b/fixture/vcr_cassettes/photo_for_venue.json
@@ -1,0 +1,39 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "User-Agent": "bees/0.1.0"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.foursquare.com/v2/venues/510d6edfe4b0d7e116e6d1e0/photos?client_id=CLIENT_ID&client_secret=CLIENT_SECRET&limit=1&offset=1&v=20160301"
+    },
+    "response": {
+      "body": "{\"meta\":{\"code\":200,\"requestId\":\"59a43bae4434b9555afa5d3a\"},\"response\":{\"photos\":{\"count\":1,\"items\":[{\"id\":\"58012834d67ce59c2758cbad\",\"createdAt\":1476470836,\"source\":{\"name\":\"Yext Yext\",\"url\":\"http:\\/\\/yext.com\"},\"prefix\":\"https:\\/\\/igx.4sqi.net\\/img\\/general\\/\",\"suffix\":\"\\/87388367_pScNo0C-DX8cMVBgNYM2BzBfrgEA6_CpOIhPF7ezONM.jpg\",\"width\":619,\"height\":330,\"user\":{\"id\":\"87388367\",\"firstName\":\"Yext\",\"lastName\":\"Yext\",\"gender\":\"none\",\"photo\":{\"prefix\":\"https:\\/\\/igx.4sqi.net\\/img\\/user\\/\",\"suffix\":\"\\/blank_boy.png\",\"default\":true}},\"visibility\":\"public\"}],\"dupesRemoved\":0}}}",
+      "headers": {
+        "Server": "nginx",
+        "Content-Type": "application/json; charset=utf-8",
+        "Access-Control-Allow-Origin": "*",
+        "Tracer-Time": "18",
+        "X-RateLimit-Path": "/v2/venues/X/photos",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4989",
+        "Strict-Transport-Security": "max-age=31536000",
+        "X-ex": "fastly_cdn",
+        "Content-Length": "578",
+        "Accept-Ranges": "bytes",
+        "Date": "Mon, 28 Aug 2017 15:50:06 GMT",
+        "Via": "1.1 varnish",
+        "Connection": "keep-alive",
+        "X-Served-By": "cache-bma7024-BMA",
+        "X-Cache": "MISS",
+        "X-Cache-Hits": "0",
+        "Vary": "Accept-Encoding,User-Agent,Accept-Language"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/lib/bees/photo.ex
+++ b/lib/bees/photo.ex
@@ -1,0 +1,40 @@
+defmodule Bees.Photo do
+  @derive Poison.Encoder
+
+  defstruct id: nil, createdAt: nil, source: nil, prefix: nil, suffix: nil,
+    width: nil, height: nil, user: nil, checkin: nil, visibility: nil
+
+  def from_venue(client, id, limit \\ 100, offset \\ 0) do
+    params = [
+      limit: limit,
+      offset: offset,
+      v: "20160301"
+    ]
+
+    case Bees.Client.get(client, "/venues/#{id}/photos", params, false) do
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        response = decode_many(body)
+        {:ok, response["response"]["photos"]}
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  # Private Helpers
+
+  defp decode_many(body) do
+    mapping = %{
+      "response" => %{
+        "photos" => %{
+          "items" => [decoder]
+        }
+      }
+    }
+
+    Poison.decode!(body, as: mapping)
+  end
+
+  defp decoder() do
+    %Bees.Photo{}
+  end
+end

--- a/test/photo_test.exs
+++ b/test/photo_test.exs
@@ -1,0 +1,26 @@
+defmodule PhotoTest do
+  use ExUnit.Case
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+
+  doctest Bees.Photo
+
+  defp client() do
+    %Bees.Client{
+      client_id: "CLIENT_ID",
+      client_secret: "CLIENT_SECRET",
+      access_token: "ACCESS_TOKEN"
+    }
+  end
+
+  setup_all do
+    Bees.Client.start
+  end
+
+  test "for_venue" do
+    use_cassette "photo_for_venue" do
+      {status, body} = Bees.Photo.from_venue(client, "510d6edfe4b0d7e116e6d1e0", 1, 1)
+      assert status == :ok
+      assert Enum.count(body["items"]) == 1
+    end
+  end
+end


### PR DESCRIPTION
In this PR support for [Photos from a Venue](https://developer.foursquare.com/docs/venues/photos) endpoint has been added.