### PR TITLE
Bump version in README to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The package can be installed as:
   1. Add bees to your list of dependencies in `mix.exs`:
 
         def deps do
-          [{:bees, "~> 0.1.0"}]
+          [{:bees, "~> 0.3.0"}]
         end
 
   2. Ensure bees is started before your application:


### PR DESCRIPTION
I was copying and pasting the install instruction and noticed they're out of date. This PR bumps the README to have version `0.3.0`.