### PR TITLE
Bump httpoison

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Bees.Mixfile do
 
   defp deps do
     [
-      {:httpoison, "~> 0.11"},
+      {:httpoison, "~> 1.0"},
       {:jsx, "~> 2.6"},
       {:plug, "~> 1.0"},
       {:poison, "~> 3.0"},


### PR DESCRIPTION
httpoison is now on 1.0. This PR bumps the version.